### PR TITLE
Proposal: Fix blocking GUI by transitions from time per simday to time between simdays ( = time for the GUI to update/time to inspect the GUI)

### DIFF
--- a/main/cpp/guicontroller/controllermain.qml
+++ b/main/cpp/guicontroller/controllermain.qml
@@ -10,6 +10,8 @@ ApplicationWindow {
     visible: true
     title: qsTr("GuiController")
 
+    property var autostepping: false;
+
     Backend {
         id: backend
         objectName: 'backend'
@@ -22,6 +24,9 @@ ApplicationWindow {
             stepButtonOneDay.enabled = true
             infectedNr.text = infectedCount
             dayNr.text = day
+            if (autostepping) {
+                stepTimer.start();
+            }
         }
 
     }
@@ -40,7 +45,7 @@ ApplicationWindow {
             }
 
             Text {
-                text: "Seconds / Day"
+                text: "seconds between days"
             }
             Button {
                 text: "Start"
@@ -48,9 +53,11 @@ ApplicationWindow {
                     if (text == "Start") {
                         stepTimer.interval = secondsPerDay.value * 1000
                         stepTimer.start()
+                        autostepping = true;
                         text = "Pause"
                     } else {
                         stepTimer.stop()
+                        autostepping = false;
                         text = "Start"
                     }
 
@@ -59,7 +66,7 @@ ApplicationWindow {
             Timer {
                 id: stepTimer
                 running: false
-                repeat: true
+                repeat: false
                 onTriggered: stepDay(1)
             }
         }

--- a/main/cpp/guilauncher/launchermain.qml
+++ b/main/cpp/guilauncher/launchermain.qml
@@ -4,7 +4,7 @@ import QtQuick.Controls.Styles 1.4
 import QtLocation 5.3
 import QtQuick.Window 2.0
 import QtQuick.Layouts 1.2
-import QtQuick.Dialogs 1.3
+import QtQuick.Dialogs 1.2
 
 import io.bistromatics.launcher 1.0
 


### PR DESCRIPTION
@thomasave dit lijkt me beter dan dat de UI blokkeert bij zwaardere simulaties of tragere PC's. Nu zitten er altijd twee seconden tussen de dagen, en wordt er niet gesimuleerd om de twee seconden.